### PR TITLE
Suggest better location pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install nginx-full --with-xslt
 
 2. Add the following lines to your `nginx.conf` location:
    ```nginx
-   location / {
+   location ~ /$ {
        autoindex on;
        autoindex_format xml;
 


### PR DESCRIPTION
The suggested pattern location / matches ANY .xml too. Using location ~ /$ instead only matches directories, and it doesn't interfere with index directive (e.g. index index.php).